### PR TITLE
feat/pagination

### DIFF
--- a/src/components/DogList/DogList.component.tsx
+++ b/src/components/DogList/DogList.component.tsx
@@ -1,12 +1,19 @@
 import { Box, Button, Grid, Group, HoverCard, Radio } from "@mantine/core";
-import { useEffect, useState, useMemo } from "react";
-import useDogPagination from "../../hooks/usePagination";
+import { useEffect, useMemo, useState } from "react";
+import usePagination from "../../hooks/usePagination";
 import { Dog } from "../../types";
 import { fetchDogsByIds } from "../../utils/api";
 import { DogCard } from "../DogCard/DogCard.component";
 
 const DogList: React.FunctionComponent = () => {
-  const { nextDogs, nextQuery, prevQuery, fetchDogs, loadingPagination, currentFrom } = useDogPagination();
+  const {
+    nextDogs,
+    nextQuery,
+    prevQuery,
+    fetchDogs,
+    loadingPagination,
+    currentFrom,
+  } = usePagination();
   const [dogs, setDogs] = useState<Dog[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [sortOption, setSortOption] = useState<string>("breed-asc");
@@ -56,7 +63,11 @@ const DogList: React.FunctionComponent = () => {
             <Button>Sort</Button>
           </HoverCard.Target>
           <HoverCard.Dropdown>
-            <Radio.Group label="Sort by" value={sortOption} onChange={setSortOption}>
+            <Radio.Group
+              label="Sort by"
+              value={sortOption}
+              onChange={setSortOption}
+            >
               <Group align="center" mt="xs">
                 <Radio value="age-asc" label="Age (young to old)" />
                 <Radio value="age-desc" label="Age (old to young)" />
@@ -77,10 +88,16 @@ const DogList: React.FunctionComponent = () => {
       </Grid>
 
       <Group mt="20px">
-        <Button disabled={!prevQuery} onClick={() => fetchDogs(currentFrom - 25)}>
+        <Button
+          disabled={!prevQuery}
+          onClick={() => fetchDogs(currentFrom - 25)}
+        >
           Previous
         </Button>
-        <Button disabled={!nextQuery} onClick={() => fetchDogs(currentFrom + 25)}>
+        <Button
+          disabled={!nextQuery}
+          onClick={() => fetchDogs(currentFrom + 25)}
+        >
           Next
         </Button>
       </Group>

--- a/src/hooks/usePagination.tsx
+++ b/src/hooks/usePagination.tsx
@@ -1,0 +1,41 @@
+import { useState, useEffect } from "react";
+import { fetchAllDogs } from "../utils/api"; // Ensure this is correctly imported
+
+interface DogPagination {
+  resultIds: string[];
+  total: number;
+  next: string;
+}
+
+const useDogPagination = () => {
+  const [nextDogs, setNextDogs] = useState<string[]>([]);
+  const [total, setTotal] = useState<number>(0);
+  const [nextQuery, setNextQuery] = useState<string | null>(null);
+  const [prevQuery, setPrevQuery] = useState<string | null>(null);
+  const [loadingPagination, setLoadingPagination] = useState<boolean>(false);
+  const [currentFrom, setCurrentFrom] = useState<number>(0); // Track current pagination position
+
+  const fetchDogs = async (from: number) => {
+    setLoadingPagination(true);
+    try {
+      const response: DogPagination = await fetchAllDogs(from);
+      setNextDogs(response.resultIds);
+      setTotal(response.total);
+      setNextQuery(response.next || null);
+      setPrevQuery(from > 0 ? `/dogs/search?size=25&from=${Math.max(0, from - 25)}` : null);
+      setCurrentFrom(from);
+    } catch (error) {
+      console.error("Error fetching dogs:", error);
+    } finally {
+      setLoadingPagination(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchDogs(0); 
+  }, []);
+
+  return { nextDogs, total, nextQuery, prevQuery, fetchDogs, loadingPagination, currentFrom };
+};
+
+export default useDogPagination;

--- a/src/hooks/usePagination.tsx
+++ b/src/hooks/usePagination.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { fetchAllDogs } from "../utils/api"; // Ensure this is correctly imported
 
 interface DogPagination {
@@ -7,7 +7,7 @@ interface DogPagination {
   next: string;
 }
 
-const useDogPagination = () => {
+const usePagination = () => {
   const [nextDogs, setNextDogs] = useState<string[]>([]);
   const [total, setTotal] = useState<number>(0);
   const [nextQuery, setNextQuery] = useState<string | null>(null);
@@ -22,7 +22,9 @@ const useDogPagination = () => {
       setNextDogs(response.resultIds);
       setTotal(response.total);
       setNextQuery(response.next || null);
-      setPrevQuery(from > 0 ? `/dogs/search?size=25&from=${Math.max(0, from - 25)}` : null);
+      setPrevQuery(
+        from > 0 ? `/dogs/search?size=25&from=${Math.max(0, from - 25)}` : null
+      );
       setCurrentFrom(from);
     } catch (error) {
       console.error("Error fetching dogs:", error);
@@ -32,10 +34,18 @@ const useDogPagination = () => {
   };
 
   useEffect(() => {
-    fetchDogs(0); 
+    fetchDogs(0);
   }, []);
 
-  return { nextDogs, total, nextQuery, prevQuery, fetchDogs, loadingPagination, currentFrom };
+  return {
+    nextDogs,
+    total,
+    nextQuery,
+    prevQuery,
+    fetchDogs,
+    loadingPagination,
+    currentFrom,
+  };
 };
 
-export default useDogPagination;
+export default usePagination;

--- a/src/pages/Search/Search.page.tsx
+++ b/src/pages/Search/Search.page.tsx
@@ -3,7 +3,6 @@ import {
   ComboboxItem,
   Container,
   Group,
-  Pagination,
   Select,
   Title,
 } from "@mantine/core";
@@ -11,7 +10,11 @@ import { useEffect, useState } from "react";
 import { IoSearch } from "react-icons/io5";
 
 import DogList from "../../components/DogList/DogList.component";
-import { fetchAllDogs, fetchBreeds, fetchDogsByBreed } from "../../utils/api";
+import {
+  fetchAllDogs,
+  fetchBreeds,
+  fetchDogsByBreed,
+} from "../../utils/api";
 
 interface ISearchProps {}
 
@@ -19,15 +22,13 @@ export const Search: React.FunctionComponent<ISearchProps> = () => {
   const [breeds, setBreeds] = useState<string[]>([]);
   const [selectedBreed, setSelectedBreed] = useState<string>("");
   const [dogIds, setDogIds] = useState<string[]>([]);
-  const [total, setTotal] = useState<number>();
 
   // Fetch all breeds on component mount
-  // fetch all dog, when next add 25 to from, when prev sub 25 from
   useEffect(() => {
     const getAllDogs = async () => {
       const dogPage = await fetchAllDogs(0);
-      setDogIds(dogPage.resultIds); 
-      setTotal(dogPage.total / 25);
+      setDogIds(dogPage.resultIds);
+      console.log("next", dogPage.next);
     };
     getAllDogs();
     const getBreeds = async () => {
@@ -47,7 +48,6 @@ export const Search: React.FunctionComponent<ISearchProps> = () => {
     if (selectedBreed) {
       const ids = await fetchDogsByBreed([selectedBreed]);
       setDogIds(ids.resultIds);
-      setTotal(ids.total)
     }
   };
 
@@ -57,8 +57,8 @@ export const Search: React.FunctionComponent<ISearchProps> = () => {
         <Title>Dog Search</Title>
         <Group>
           <Select
-            label="Your favorite bread"
-            placeholder="Pick a bread"
+            label="Your favorite breed"
+            placeholder="Pick a breed"
             data={breeds}
             clearable
             value={selectedBreed}
@@ -76,8 +76,7 @@ export const Search: React.FunctionComponent<ISearchProps> = () => {
           </Button>
         </Group>
       </form>
-      <DogList dogIds={dogIds} total={total || 0}/>
-      {/* <Pagination total={total || 0} color="green" radius="xl" /> */}
+      <DogList />
     </Container>
   );
 };

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -35,17 +35,6 @@ export const fetchAllDogs= async (selectedFrom: number): Promise<{ resultIds: st
     }
   };
 
-//Function to fetch next page
-// export const fetchNextPage = async (selectedFrom: number): Promise<{resultIds: string[]}> => {
-//   try {
-//     const response = await api.get<{resultIds: string[]}>(`/dogs/search?size=25&from=${selectedFrom}"`);
-//     return {resultIds: response.data.resultIds};
-//   } catch (error) {
-//     console.error("Error fetching breeds:", error);
-//     return {resultIds: []};
-//   }
-// };
-
 // Function to fetch dogs by breed
 export const fetchDogsByBreed = async (selectedBreeds: string[]): Promise<{ resultIds: string[], total: number }> => {
   try {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { Dog } from "../types";
 
 
-export const api = axios.create({
+const api = axios.create({
   baseURL: process.env.REACT_APP_BASE_URL,
   withCredentials: true,
 });
@@ -19,20 +19,32 @@ export const fetchBreeds = async (): Promise<string[]> => {
 };
 
 //Function to fetch ALL dogs
-export const fetchAllDogs= async (selectedFrom: number): Promise<{ resultIds: string[], total: number }> => {
+export const fetchAllDogs= async (selectedFrom: number): Promise<{ resultIds: string[], total: number, next:string }> => {
     try {
-      const response = await api.get<{ resultIds: string[], total:number }>("/dogs/search", {
+      const response = await api.get<{ resultIds: string[], total:number, next: string }>("/dogs/search", {
         params: { size: 25, from: selectedFrom },
       });
       return {
         resultIds: response.data.resultIds,
         total: response.data.total,
+        next: response.data.next,
       };
     } catch (error) {
       console.error("Error fetching dogs:", error);
-      return { resultIds: [], total: 0 }; 
+      return { resultIds: [], total: 0, next: "/dogs/search?size=25&from=25" }; 
     }
   };
+
+//Function to fetch next page
+// export const fetchNextPage = async (selectedFrom: number): Promise<{resultIds: string[]}> => {
+//   try {
+//     const response = await api.get<{resultIds: string[]}>(`/dogs/search?size=25&from=${selectedFrom}"`);
+//     return {resultIds: response.data.resultIds};
+//   } catch (error) {
+//     console.error("Error fetching breeds:", error);
+//     return {resultIds: []};
+//   }
+// };
 
 // Function to fetch dogs by breed
 export const fetchDogsByBreed = async (selectedBreeds: string[]): Promise<{ resultIds: string[], total: number }> => {
@@ -61,3 +73,4 @@ export const fetchDogsByIds = async (dogIds: string[]): Promise<Dog[]> => {
     }
   };
   
+export default api;


### PR DESCRIPTION
- Use `next` & `prev` from API response
- Fetch and render new dogs when paginating
   - click "Next" or "Previous," the displayed dogs update correctly.
- useMemo to apply sorting only when needed 